### PR TITLE
prefix and rename attributes for Builder

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 3
 
 [[package]]
 name = "boring-derive"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "boring-derive"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 description = "Derive macros for some common patterns"
 authors = ["Ben Pawlowski ben@pepski.com"]

--- a/src/builder_derive.rs
+++ b/src/builder_derive.rs
@@ -1,10 +1,10 @@
 use proc_macro2::TokenStream;
-use quote::{quote, ToTokens};
+use quote::{format_ident, quote, ToTokens};
 use syn::Error;
 
 use crate::core::{
-    attr::BoolAttr,
-    container::{AttrField, AttrVariant, Container},
+    attr::{Attr, BoolAttr},
+    container::{AttrContainer, AttrField, AttrVariant, Container},
     context::Context,
     data::{Data, Style},
     symbol::Symbol,
@@ -13,12 +13,62 @@ use crate::core::{
 const BUILDER: Symbol = Symbol("builder");
 const SKIP: Symbol = Symbol("skip");
 const NO_INTO: Symbol = Symbol("no_into");
+const PREFIX: Symbol = Symbol("prefix");
+const RENAME: Symbol = Symbol("rename");
+
+struct BuilderContainer {
+    prefix: Option<String>,
+}
 
 struct BuilderVariant;
 
 struct BuilderField {
     skip: bool,
     no_into: bool,
+    rename: Option<String>,
+}
+
+impl AttrContainer for BuilderContainer {
+    fn from_ast(cx: &Context, item: &syn::DeriveInput) -> Self {
+        let mut prefix = Attr::none(cx, PREFIX);
+
+        for attr in &item.attrs {
+            if attr.path() != BUILDER {
+                continue;
+            }
+
+            if let Err(err) = attr.parse_nested_meta(|meta| {
+                if meta.path == PREFIX {
+                    let expr: syn::Expr = meta.value()?.parse()?;
+                    if let syn::Expr::Lit(syn::ExprLit {
+                        lit: syn::Lit::Str(s),
+                        ..
+                    }) = expr
+                    {
+                        prefix.set(&meta.path, s.value());
+                    } else {
+                        return Err(meta.error(format_args!(
+                            "prefix must be a string not `{}`",
+                            expr.to_token_stream().to_string()
+                        )));
+                    }
+                } else {
+                    let path = meta.path.to_token_stream().to_string();
+                    return Err(meta.error(format_args!(
+                        "unexpected builder container attribute: `{}`",
+                        path
+                    )));
+                }
+                Ok(())
+            }) {
+                cx.syn_error(err);
+            }
+        }
+
+        BuilderContainer {
+            prefix: prefix.get(),
+        }
+    }
 }
 
 impl AttrVariant for BuilderVariant {
@@ -31,6 +81,7 @@ impl AttrField for BuilderField {
     fn from_ast(cx: &Context, _index: usize, field: &syn::Field) -> Self {
         let mut skip = BoolAttr::none(cx, SKIP);
         let mut no_into = BoolAttr::none(cx, NO_INTO);
+        let mut rename = Attr::none(cx, RENAME);
 
         for attr in &field.attrs {
             if attr.path() != BUILDER {
@@ -42,6 +93,20 @@ impl AttrField for BuilderField {
                     skip.set_true(&meta.path);
                 } else if meta.path == NO_INTO {
                     no_into.set_true(&meta.path);
+                } else if meta.path == RENAME {
+                    let expr: syn::Expr = meta.value()?.parse()?;
+                    if let syn::Expr::Lit(syn::ExprLit {
+                        lit: syn::Lit::Str(s),
+                        ..
+                    }) = expr
+                    {
+                        rename.set(&meta.path, s.value());
+                    } else {
+                        return Err(meta.error(format_args!(
+                            "rename must be a string not `{}`",
+                            expr.to_token_stream().to_string()
+                        )));
+                    }
                 } else {
                     let path = meta.path.to_token_stream().to_string().replace(' ', "");
                     return Err(
@@ -57,13 +122,15 @@ impl AttrField for BuilderField {
         BuilderField {
             skip: skip.get(),
             no_into: no_into.get(),
+            rename: rename.get(),
         }
     }
 }
 
 pub(crate) fn impl_builder(ast: &syn::DeriveInput) -> syn::Result<TokenStream> {
     let ctxt = Context::new();
-    let cont: Option<Container<BuilderField, BuilderVariant>> = Container::from_ast(&ctxt, ast);
+    let cont: Option<Container<BuilderField, BuilderVariant, BuilderContainer>> =
+        Container::from_ast(&ctxt, ast);
     let cont = match cont {
         Some(cont) => cont,
         None => return Err(ctxt.check().unwrap_err()),
@@ -71,6 +138,7 @@ pub(crate) fn impl_builder(ast: &syn::DeriveInput) -> syn::Result<TokenStream> {
 
     ctxt.check()?;
 
+    let prefix = &cont.attrs.prefix.unwrap_or(String::new());
     let ident = &cont.ident;
     let vis = &ast.vis;
 
@@ -82,18 +150,23 @@ pub(crate) fn impl_builder(ast: &syn::DeriveInput) -> syn::Result<TokenStream> {
                 if f.attrs.skip {
                     None
                 } else {
+                    let method_name = if let Some(rename) = &f.attrs.rename {
+                        format_ident!("{}", rename)
+                    } else {
+                        format_ident!("{}{}", prefix, &f.original.ident.as_ref().unwrap())
+                    };
                     let field_name = &f.original.ident;
                     let field_ty = f.ty;
                     if f.attrs.no_into {
                         Some(quote! {
-                            #vis fn #field_name (mut self, value: #field_ty) -> Self {
+                            #vis fn #method_name (mut self, value: #field_ty) -> Self {
                                 self.#field_name = value;
                                 self
                             }
                         })
                     } else {
                         Some(quote! {
-                            #vis fn #field_name (mut self, value: impl Into< #field_ty >) -> Self {
+                            #vis fn #method_name (mut self, value: impl Into< #field_ty >) -> Self {
                                 self.#field_name = value.into();
                                 self
                             }

--- a/src/core/data.rs
+++ b/src/core/data.rs
@@ -25,6 +25,7 @@ where
     }
 }
 
+#[allow(dead_code)]
 pub struct Variant<'a, F, V>
 where
     F: AttrField,
@@ -37,6 +38,7 @@ where
     pub original: &'a syn::Variant,
 }
 
+#[allow(dead_code)]
 pub struct Field<'a, F>
 where
     F: AttrField,

--- a/src/from_derive.rs
+++ b/src/from_derive.rs
@@ -4,7 +4,7 @@ use syn::{spanned::Spanned, Error, Ident};
 
 use crate::core::{
     attr::BoolAttr,
-    container::{AttrField, AttrVariant, Container},
+    container::{AttrContainer, AttrField, AttrVariant, Container},
     context::Context,
     data::{Data, Field, Style},
     symbol::Symbol,
@@ -12,6 +12,14 @@ use crate::core::{
 
 const FROM: Symbol = Symbol("from");
 const SKIP: Symbol = Symbol("skip");
+
+struct FromContainer;
+
+impl AttrContainer for FromContainer {
+    fn from_ast(_cx: &Context, _item: &syn::DeriveInput) -> Self {
+        FromContainer
+    }
+}
 
 struct FromVariant {
     skip: bool,
@@ -55,7 +63,8 @@ impl AttrField for FromField {
 
 pub(crate) fn impl_from(ast: &syn::DeriveInput) -> syn::Result<TokenStream> {
     let ctxt = Context::new();
-    let cont: Option<Container<FromField, FromVariant>> = Container::from_ast(&ctxt, ast);
+    let cont: Option<Container<FromField, FromVariant, FromContainer>> =
+        Container::from_ast(&ctxt, ast);
     let cont = match cont {
         Some(cont) => cont,
         None => return Err(ctxt.check().unwrap_err()),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,6 +63,24 @@
 //! }
 //! ```
 //!
+//! if you need to alter the names of the associated methods use `prefix` and/or `rename`
+//! attributes.
+//! ```text
+//! #[derive(Builder)]
+//! #[builder(prefix = "set_")]
+//! struct Example {
+//!     item: String,
+//!     #[builder(rename = "num")]
+//!     value: usize,
+//! }
+//!
+//! // will generate
+//! impl Example {
+//!     fn set_item(mut self, ..) -> Self {..}
+//!     fn num(mut self, ..) -> Self {..}
+//! }
+//! ```
+//!
 //! The Builder pattern is not defined for enums, unit-like struct, newtypes, and tuple structs
 //!
 //! # From

--- a/tests/builder/prefix.rs
+++ b/tests/builder/prefix.rs
@@ -1,0 +1,12 @@
+use boring_derive::Builder;
+
+#[derive(Debug, Default, Builder)]
+#[builder(prefix = "set_")]
+struct Example {
+    item: String,
+}
+
+fn main() {
+    let ex = Example::default().set_item("balls");
+    println!("{:?}", ex);
+}

--- a/tests/builder/prefix_non_string.rs
+++ b/tests/builder/prefix_non_string.rs
@@ -1,0 +1,12 @@
+use boring_derive::Builder;
+
+#[derive(Debug, Default, Builder)]
+#[builder(prefix = 1)]
+struct Example {
+    item: String,
+}
+
+fn main() {
+    let ex = Example::default().set_item("balls");
+    println!("{:?}", ex);
+}

--- a/tests/builder/prefix_non_string.stderr
+++ b/tests/builder/prefix_non_string.stderr
@@ -1,0 +1,14 @@
+error: prefix must be a string not `1`
+ --> tests/builder/prefix_non_string.rs:4:11
+  |
+4 | #[builder(prefix = 1)]
+  |           ^^^^^^^^^^
+
+error[E0599]: no method named `set_item` found for struct `Example` in the current scope
+  --> tests/builder/prefix_non_string.rs:10:33
+   |
+5  | struct Example {
+   | -------------- method `set_item` not found for this struct
+...
+10 |     let ex = Example::default().set_item("balls");
+   |                                 ^^^^^^^^ method not found in `Example`

--- a/tests/builder/rename.rs
+++ b/tests/builder/rename.rs
@@ -1,0 +1,12 @@
+use boring_derive::Builder;
+
+#[derive(Debug, Default, Builder)]
+struct Example {
+    #[builder(rename = "value")]
+    item: String,
+}
+
+fn main() {
+    let ex = Example::default().value("val");
+    println!("{:?}", ex);
+}

--- a/tests/builder/rename_non_string.rs
+++ b/tests/builder/rename_non_string.rs
@@ -1,0 +1,12 @@
+use boring_derive::Builder;
+
+#[derive(Debug, Default, Builder)]
+struct Example {
+    #[builder(rename = 1)]
+    item: String,
+}
+
+fn main() {
+    let ex = Example::default().value("val");
+    println!("{:?}", ex);
+}

--- a/tests/builder/rename_non_string.stderr
+++ b/tests/builder/rename_non_string.stderr
@@ -1,0 +1,14 @@
+error: rename must be a string not `1`
+ --> tests/builder/rename_non_string.rs:5:15
+  |
+5 |     #[builder(rename = 1)]
+  |               ^^^^^^^^^^
+
+error[E0599]: no method named `value` found for struct `Example` in the current scope
+  --> tests/builder/rename_non_string.rs:10:33
+   |
+4  | struct Example {
+   | -------------- method `value` not found for this struct
+...
+10 |     let ex = Example::default().value("val");
+   |                                 ^^^^^ method not found in `Example`

--- a/tests/from/skip.rs
+++ b/tests/from/skip.rs
@@ -9,12 +9,6 @@ enum Example {
 }
 
 fn main() {
-    let ex: Example = ().into();
-    println!("{:?}", ex);
-
     let ex: Example = 1.3.into();
-    println!("{:?}", ex);
-
-    let ex: Example = "something".to_string().into();
     println!("{:?}", ex);
 }

--- a/tests/from/skip.stderr
+++ b/tests/from/skip.stderr
@@ -1,10 +1,10 @@
 error[E0277]: the trait bound `Example: From<{float}>` is not satisfied
-  --> tests/from/skip.rs:15:27
+  --> tests/from/skip.rs:12:27
    |
-15 |     let ex: Example = 1.3.into();
+12 |     let ex: Example = 1.3.into();
    |                           ^^^^ the trait `From<{float}>` is not implemented for `Example`, which is required by `{float}: Into<_>`
    |
    = help: the following other types implement trait `From<T>`:
-             <Example as From<String>>
              <Example as From<()>>
+             <Example as From<String>>
    = note: required for `{float}` to implement `Into<Example>`

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -3,6 +3,8 @@ fn test() {
     let t = trybuild::TestCases::new();
     // builder
     t.pass("tests/builder/struct.rs");
+    t.pass("tests/builder/prefix.rs");
+    t.pass("tests/builder/rename.rs");
     t.compile_fail("tests/builder/skip.rs");
     t.compile_fail("tests/builder/no_into.rs");
     t.compile_fail("tests/builder/enum.rs");
@@ -10,6 +12,8 @@ fn test() {
     t.compile_fail("tests/builder/tuple.rs");
     t.compile_fail("tests/builder/unit.rs");
     t.compile_fail("tests/builder/bad_attr.rs");
+    t.compile_fail("tests/builder/prefix_non_string.rs");
+    t.compile_fail("tests/builder/rename_non_string.rs");
     // from
     t.pass("tests/from/enum.rs");
     t.pass("tests/from/struct.rs");


### PR DESCRIPTION
Added `prefix` attribute for the whole `struct` and `rename` for individual fields.